### PR TITLE
ルームに参加機能の実装

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -17,3 +17,4 @@ class CommentsController < ApplicationController
     params.require(:comment).permit(:text).merge(user_id: current_user.id, room_id: params[:room_id])
   end
 end
+  

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -25,6 +25,14 @@ class RoomsController < ApplicationController
     @comment = Comment.new
   end
 
+  # 参加ボタンでルームにユーザーを登録
+  def join
+    @room = Room.find(params[:id])
+    @room.users << current_user
+    @room.save
+    redirect_to room_path(@room)
+  end
+
   private
   def room_params
     params.require(:room).permit(:name, :text).merge(user_ids: current_user.id)

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,5 +1,6 @@
 class RoomsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :confirm_join, only: :show
 
   def index
     @rooms = Room.includes(:users).order("created_at DESC")
@@ -25,6 +26,10 @@ class RoomsController < ApplicationController
     @comment = Comment.new
   end
 
+
+  def confirm
+  end
+
   # 参加ボタンでルームにユーザーを登録
   def join
     @room = Room.find(params[:id])
@@ -36,5 +41,12 @@ class RoomsController < ApplicationController
   private
   def room_params
     params.require(:room).permit(:name, :text).merge(user_ids: current_user.id)
+  end
+
+  def confirm_join
+    @room = Room.find(params[:id])
+    unless @room.users.include?(current_user)
+      render :confirm
+    end
   end
 end

--- a/app/views/rooms/confirm.html.erb
+++ b/app/views/rooms/confirm.html.erb
@@ -1,0 +1,5 @@
+<h1>参加確認ページ</h1>
+
+  <%= link_to "「#{@room.name}」に参加する", join_room_path(@room) %>
+  <%= link_to "トップページへ戻る", root_path %>
+  

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,11 +1,19 @@
 <div class="wrapper">
   <div class="left-side">
+    <% if @room.users.include?(current_user) %>
+      <p>参加済み</p>
+    <% else %>
+      <%= link_to "参加する", join_room_path(@room) %>
+    <% end %>
+
     <p>ルーム名：<%= @room.name %></p>
     <p>参加ユーザー数：<%= @room.users.count %></p>
     <p>＜参加ユーザー＞</p>
-    <% @room.users.each do |user| %>
-      <%= user.name %>
-    <% end %>
+    <ul>
+      <% @room.users.each do |user| %>
+        <li><%= user.name %></li>
+      <% end %>
+    </ul>
   </div>
 
   <div class="main">

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,10 +1,5 @@
 <div class="wrapper">
   <div class="left-side">
-    <% if @room.users.include?(current_user) %>
-      <p>参加済み</p>
-    <% else %>
-      <%= link_to "参加する", join_room_path(@room) %>
-    <% end %>
 
     <p>ルーム名：<%= @room.name %></p>
     <p>参加ユーザー数：<%= @room.users.count %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
   devise_for :users
   resources :rooms do
     resources :comments, only: :create
+    member do
+      get :join
+    end
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :rooms do
     resources :comments, only: :create
     member do
+      get :confirm
       get :join
     end
   end


### PR DESCRIPTION
Close #5 

## What
・ルーム内に「参加する」ボタンを実装
・「参加する」をクリックで、参加ユーザーに追加（room.usersに追加）
・ルーム入室時に参加ユーザーに含まれていなければ、参加確認ページへ遷移するよう変更

## Why
・未参加ユーザーがルームに参加できるようにするため

## 懸念
・参考資料をベースに実装したものの、ベストな実装かは不明
・参加済みのルームでも、参加確認ページが一瞬映ることがある