### PR TITLE
showアクションで、roomのcommentを取得する

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -22,7 +22,7 @@ class RoomsController < ApplicationController
   
   def show
     @room = Room.find(params[:id])
-    @comments = Comment.includes(:user)
+    @comments = @room.comments.includes(:user)
     @comment = Comment.new
   end
 


### PR DESCRIPTION
Close #19 

## What
・showアクションでコメント全体を指定していた記述を、  現ルームのコメントを取得するように変更
・画面でそれぞれのメッセージが表示されていることを確認

## Why
・バグを解消するため