### PR TITLE
ルームの編集・削除機能の追加

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,6 +1,7 @@
 class RoomsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :confirm_join, only: :show
+  before_action :set_room, only: [:show, :edit, :update, :join, :confirm_join]
 
   def index
     @rooms = Room.includes(:users).order("created_at DESC")
@@ -22,30 +23,49 @@ class RoomsController < ApplicationController
   end
   
   def show
-    @room = Room.find(params[:id])
+    set_room
     @comments = @room.comments.includes(:user)
     @comment = Comment.new
   end
 
+  def edit
+    set_room
+  end
 
+  def update
+    set_room
+    if @room.valid?
+      @room.update(room_params)
+      redirect_to room_path(@room)
+    else
+      render :edit
+    end
+  end
+
+  # ルーム入室確認ビュー
   def confirm
   end
 
   # 参加ボタンでルームにユーザーを登録
   def join
-    @room = Room.find(params[:id])
+    set_room
     @room.users << current_user
     @room.save
     redirect_to room_path(@room)
   end
 
   private
+  def set_room
+    @room = Room.find(params[:id])
+  end
+
+
   def room_params
     params.require(:room).permit(:name, :text).merge(user_ids: current_user.id)
   end
 
   def confirm_join
-    @room = Room.find(params[:id])
+    set_room
     unless @room.users.include?(current_user)
       render :confirm
     end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -42,6 +42,15 @@ class RoomsController < ApplicationController
     end
   end
 
+  def destroy
+    set_room
+    if @room.destroy
+      redirect_to root_path
+    else
+      render :show
+    end
+  end
+
   # ルーム入室確認ビュー
   def confirm
   end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,7 +1,7 @@
 class Room < ApplicationRecord
   validates :name, presence: true
 
-  has_many :room_users
+  has_many :room_users, dependent: :destroy
   has_many :users, through: :room_users
-  has_many :comments
+  has_many :comments, dependent: :destroy
 end

--- a/app/views/rooms/edit.html.erb
+++ b/app/views/rooms/edit.html.erb
@@ -1,0 +1,15 @@
+<p><%= @room.name %>の編集ページ</p>
+
+<%= form_with model: @room, local: true do |f| %>
+  <div>
+    <%= f.label :name, "name" %>
+    <%= f.text_field :name %>
+  </div>
+  <div>
+    <%= f.label :text, "text" %>
+    <%= f.text_area :text %>
+  </div>
+  <div>
+    <%= f.submit "更新する" %>
+  </div>
+<% end %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -2,6 +2,8 @@
   <div class="left-side">
 
     <p>ルーム名：<%= @room.name %></p>
+    <%= link_to  "編集", edit_room_path(@room) %>
+    <%= link_to  "削除", room_path(@room), method: :delete %>
     <p>参加ユーザー数：<%= @room.users.count %></p>
     <p>＜参加ユーザー＞</p>
     <ul>


### PR DESCRIPTION
Close #13 

## What
・ルーム内に編集・削除ボタンを配置
・編集ボタンからルーム名とテキストを編集する画面へ遷移、更新ボタンで更新
・削除ボタンでルームを削除し、トップページへ遷移する

## What
・ルーム情報を編集、ルームを削除できるようにするため

## 今後改善したい
・ルーム参加者全員が、編集・削除が可能になっている→作成者のみ可能にする